### PR TITLE
Clarify Extend behavior for the administered molecule of events

### DIFF
--- a/part-4/modularization-concept.md
+++ b/part-4/modularization-concept.md
@@ -221,10 +221,10 @@ The tree structure of the event is extended. This means:
 
  - **Parameters** list is extended. If the same parameter is defined in multiple modules, the parameter from the module that is lower in the hierarchy is used.
 
-- **Administered molecule** is extended.
+- **Administered molecule** is *not* combined. When different modules define the same event (application) for **different** administered molecules, only the administered molecule of the module that is **higher in the hierarchy** (the first-selected module) is used; the administered molecule defined in a module lower in the hierarchy (selected later) is ignored. Note that this is the opposite precedence to parameters (above), where the lower module wins.
 
 {% hint style="warning" %}
- This results in a malformed event if different molecules are defined in different modules!
+Avoid defining the same event (application) for **different** administered molecules across modules. Under "Extend" the later module's administered molecule is silently dropped, so a redefinition of the administered molecule does not take effect. Always verify the administered molecule in the created simulation.
 {% endhint %}
 
 For each event:


### PR DESCRIPTION
## What

Updates the **Events → Merge behavior "Extend"** section of `part-4/modularization-concept.md` to describe the **current v13 behavior** of the *administered molecule* when the same event (application) is defined in more than one module.

## Why

The section currently states that under "Extend" the **administered molecule is extended**, with a warning that this *"results in a malformed event if different molecules are defined in different modules"*. This describes the old (v12) behavior and no longer matches v13.

Observed v13 behavior (controlled two-module test, one large-molecule + one small-molecule PK-Sim module, each defining the same application for a different drug):

| Merge mode | Administered molecule in the created simulation |
|---|---|
| Overwrite | the **last** module's molecule (as documented) |
| **Extend** | the **first** module's molecule only (higher in the hierarchy); the later module's molecule is **silently dropped** — not combined |

So under "Extend" the administered molecule now follows the **opposite** precedence to parameters (where the lower/later module wins), and a redefinition of the administered molecule in a later module has no effect.

## Change

- Replace "**Administered molecule** is extended." with a description of the actual behavior (first/higher-in-hierarchy module's molecule is kept; later one ignored; opposite precedence to parameters).
- Replace the "malformed event" warning with guidance to avoid equally-named events/applications across modules and to verify the administered molecule in the created simulation.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified event merge behavior when different modules specify administered molecules.
  * Documented that the administered molecule from the higher-priority module is retained, while later values are ignored.
  * Updated the associated warning text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->