### PR TITLE
Molecule type is overwritten in both merge modes

### DIFF
--- a/part-4/modularization-concept.md
+++ b/part-4/modularization-concept.md
@@ -103,7 +103,7 @@ The list of available molecules is always extended. If module `A` has molecule `
 
 #### Merge behavior "Extend"
 
-- **Molecule type** (Drug, Enzyme, Transporter, etc.) is **not** changed. If module `A` defined molecule `MolA` as Drug, and module `B` defined molecule `MolA` as Enzyme, the molecule `MolA` will be of type Drug in the final model.
+- **Molecule type** (Drug, Enzyme, Transporter, etc.) is always overwritten. If module `A` defined molecule `MolA` as Drug, and module `B` defined molecule `MolA` as Enzyme, the molecule `MolA` will be of type Enzyme in the final model.
 - **Stationary**: the property is always overwritten.
 - **Calculation methods**: The defaults are always overwritten. Be aware that calculation methods only apply to non-stationary molecules.
 - **Parameters** are always overwritten. If both modules have a parameter `MolA|Param`, the parameter from module `B` will be used. This applies to all properties of the parameter (value, formula, unit, tags etc).
@@ -112,7 +112,7 @@ The list of available molecules is always extended. If module `A` has molecule `
 
 #### Merge behavior "Overwrite"
 
-- **Molecule type** (Drug, Enzyme, Transporter, etc.) is overwritten. If module `A` defined molecule `MolA` as Drug, and module `B` defined molecule `MolA` as Enzyme, the molecule `MolA` will be of type Enzyme in the final model.
+- **Molecule type** (Drug, Enzyme, Transporter, etc.) is always overwritten. If module `A` defined molecule `MolA` as Drug, and module `B` defined molecule `MolA` as Enzyme, the molecule `MolA` will be of type Enzyme in the final model.
 - **Stationary**: the property is always overwritten.
 - **Calculation methods**: The defaults are always overwritten. Be aware that calculation methods only apply to non-stationary molecules.
 - **Parameters** are always overwritten. Only parameters existent in the last module will be present in the simulation.


### PR DESCRIPTION
Fixes the merge-behavior description of the **molecule type** in [Modularization concept → Molecules](https://github.com/Open-Systems-Pharmacology/docs/blob/v13/part-4/modularization-concept.md#molecules).

The documentation stated that under merge behavior **"Extend"** the molecule type (Drug, Enzyme, Transporter, …) is *not* changed and is retained from the module higher in the hierarchy. That is not correct: the molecule type is taken from the later module in **both** merge modes.

`SimulationBuilder.mergeMolecules` — the "Extend" path — assigns `QuantityType` unconditionally, alongside `IsFloating` and `IsXenobiotic`:

```csharp
target.IsFloating = incoming.IsFloating;
target.IsXenobiotic = incoming.IsXenobiotic;
target.QuantityType = incoming.QuantityType;
target.Icon = incoming.Icon;
```

The behavior originally *looked* different under "Extend" because the molecule `Icon` was not copied along with the type, so a merged molecule kept rendering the icon of the base module even though its type had changed. That was fixed in Open-Systems-Pharmacology/OSPSuite.Core#2853, so the type and the icon are now consistent in both modes.

Both mode sections now carry the same wording, matching the other properties that behave identically in both modes (Stationary, calculation methods, parameter type).

Refs #335 (item 4a), Open-Systems-Pharmacology/OSPSuite.Core#2852

🤖 Generated with [Claude Code](https://claude.com/claude-code)
