### PR TITLE
Document how condition lists are combined when merging modules

### DIFF
--- a/part-4/modularization-concept.md
+++ b/part-4/modularization-concept.md
@@ -66,6 +66,22 @@ During simulation creation, the modules are combined to a common model structure
 
 There are two types of combination behavior that can be defined for a module - **overwrite** or **extend**. The following sections describe how different building blocks are merged and what are the differences between the **overwrite** and the  **extend** modes, if any.
 
+### Condition lists
+
+Observers, passive transports, events, and reactions use *condition lists* - the lists titled "In container with" or "Between containers with" - to define where in the model structure they are created (see [How Tags are used](parameters-formulas-tags.md#how-tags-are-used---container-criteria-for-formulas-observers-transports-and-events)). Wherever the sections below state that such a list is *extended*, the following rules apply:
+
+- All conditions defined in module `B` are added to the conditions defined in module `A`. Conditions are never removed. A condition defined in both modules is added twice, which does not change the result of the evaluation.
+- A **condition group** is treated as a single condition of the list. It is added as a whole, keeping the conditions and the operator (AND/OR) defined *within* the group. Condition groups of different modules are never combined with each other, and the operator within a group is never changed.
+- The **operator** (AND/OR) of the condition list itself is always taken from module `B`, even if module `B` defines only a single condition.
+
+Under the merge behavior "Overwrite", the complete condition list, including its operator, is taken from module `B`.
+
+{% hint style="warning" %}
+Because the operator of the condition list is always taken from the module lower in the hierarchy, an extension module can change the meaning of the conditions defined in a module higher in the hierarchy. Example: module `A` defines the condition list `(Condition group 1) OR (Condition group 2)`, and module `B` adds a single condition to the same list using the AND operator. The resulting condition list is `(Condition group 1) AND (Condition group 2) AND (condition from module B)`, so an entity that was created in the containers matching *either* group is now only created in the containers matching *both* of them.
+
+Note that AND is the default operator, and that the operator of a list with only one condition is not visible in the user interface. Always verify the resulting model structure in the created simulation.
+{% endhint %}
+
 ### Spatial structure
 
 #### Merge behavior "Extend"


### PR DESCRIPTION
Closes #357.

Adds a **Condition lists** section to *Creating simulations from modules and combination rules*, describing what "extended" means for the container criteria of observers, passive transports, events, and reactions — including condition groups, which were documented in #368 but whose behavior when modules are combined was not covered.

The rules were derived from `SimulationBuilder.mergeDescriptorCriteria` in OSPSuite.Core:

```csharp
target.Operator = source.Operator;
source.Each(t => target.Add(t.CloneCondition()));
```

- Conditions of the later module are appended; nothing is ever removed, and duplicates are not filtered out (`DescriptorCriteria` is a plain `List<ITagCondition>`).
- A condition group is an `ITagCondition` in its own right (`ConditionGroup : DescriptorCriteria, ITagCondition`), so it is appended as a single entry and `CloneCondition()` deep-clones it with its own operator and conditions. Groups of two modules are therefore never combined with each other.
- The operator of the list itself is overwritten unconditionally, regardless of how many conditions either module contributes.

The warning covers the practical trap behind the issue: a list holding a single condition has no visible operator in MoBi but still stores one, and it defaults to `And` (`DescriptorCriteria.Operator`). An extension module that adds one condition can therefore silently turn an earlier module's `OR` list into an `AND` list, which changes the set of containers the entity is created in.

Scope notes:

- The section is deliberately worded as "wherever the sections below state that such a list is *extended*", so it stays correct independently of #355 and #356, where the per-building-block statements for reactions and observers are being corrected. Those are tracked as implementation bugs in Open-Systems-Pharmacology/MoBi#2490 and Open-Systems-Pharmacology/MoBi#2491, and only the sections concerned will need an update once they are resolved.
- `ConditionGroup` was added to OSPSuite.Core after the module merge logic (Open-Systems-Pharmacology/OSPSuite.Core#2845), and no test covers a condition group going through a module merge. What is documented here is the behavior of the current implementation — if appending groups is not the intended semantics, this section should be revisited together with the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on how condition lists are merged or overwritten across modules.
  * Documented how operators are selected during merges.
  * Added a warning that operator changes may alter the model structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->