### PR TITLE
Correct the merge rule for active transports of a molecule

### DIFF
--- a/part-4/converting-v12-projects-to-v13.md
+++ b/part-4/converting-v12-projects-to-v13.md
@@ -44,14 +44,14 @@ The table below summarizes the behavioral changes. Only **Parameter Values** and
 
 - **Merge behavior "Extend"**
   - **Parameters** are overwritten individually: a parameter defined in both modules takes the later module's definition, while parameters present only in the higher module are **retained**.
-  - **Active transports** are **extended** (new ones added; existing ones merged).
+  - **Active transports** are **extended** (new ones added; for an active transport process defined in both modules only its **parameters** are merged — its kinetic equation, source/target criteria and process rate parameter properties are kept from the higher module, see [Molecules](modularization-concept.md#molecules)). (TODO https://github.com/Open-Systems-Pharmacology/MoBi/issues/2493)
   - Molecule **type** (Drug, Enzyme, Transporter, …), **stationary**, **calculation methods** (defaults), and **parameter type** (local/global) are overwritten — the later module wins, as in v12.
 - **Merge behavior "Overwrite"**
   - Only the parameters present in the last module are retained.
   - Active transports are **completely** replaced.
   - The molecule properties listed above are overwritten as well, exactly as under "Extend".
 
-**Migration impact — high.** A v12 Extension module set to "Extend" that redefined a molecule expecting full replacement now instead *merges* into the existing molecule: leftover parameters and active transports from the base module are retained. To reproduce the v12 result, set the module to **"Overwrite"**.
+**Migration impact — high.** A v12 Extension module set to "Extend" that redefined a molecule expecting full replacement now instead *merges* into the existing molecule: leftover parameters and active transports from the base module are retained. A redefinition of the **kinetic equation** of an existing active transport process under "Extend" has **no effect at all** — the equation of the higher module is kept, while parameters changed in the same redefinition *are* applied. To reproduce the v12 result, set the module to **"Overwrite"**.
 
 The molecule *properties* are the exception — type, stationary, calculation methods and parameter type are overwritten by the later module in both modes, so they need no migration attention. What changes between v12 and v13 is the treatment of the molecule's **parameters** and **active transports**.
 

--- a/part-4/modularization-concept.md
+++ b/part-4/modularization-concept.md
@@ -124,7 +124,7 @@ The list of available molecules is always extended. If module `A` has molecule `
 - **Calculation methods**: The defaults are always overwritten. Be aware that calculation methods only apply to non-stationary molecules.
 - **Parameters** are always overwritten. If both modules have a parameter `MolA|Param`, the parameter from module `B` will be used. This applies to all properties of the parameter (value, formula, unit, tags etc).
 - **Parameter type** (local/global) is always overwritten.
-- **Active Transports** are extended. New transports are added, existing are extended using the merge behavior (parameters added, properties overwritten, etc).
+- **Active Transports** are extended. Transporter molecules and active transport processes that are not defined in module `A` are added. For an active transport process that is defined in both modules, only the **parameters** are extended - new parameters are added, and a parameter defined in both modules is taken from module `B`. Its other properties are *not* overwritten: the equation in the **Kinetic** tab, the **source** and **target** container criteria, and the "Create process rate parameter" and "Plot process rate parameter" properties of module `A` are kept. (TODO https://github.com/Open-Systems-Pharmacology/MoBi/issues/2493)
 
 #### Merge behavior "Overwrite"
 


### PR DESCRIPTION
Item 3 of the re-review in Open-Systems-Pharmacology/MoBi#335: the Molecules section states that for an active transport defined in two modules the existing one is "extended using the merge behavior (parameters added, properties overwritten, etc)". Only the first half is true.

An active transport process is a `TransportBuilder` stored under a `TransporterMoleculeContainer` inside the `MoleculeBuilder`. All three are containers, so when molecules are merged they are processed only by the generic container merge (`ContainerMergeTask.MergeContainers`), which copies `Mode` and `Tags` and replaces leaf children by name — the parameters. `SimulationBuilder.mergeTransports`, which does merge the formula, both criteria and the process rate flags, is applied only to the **Passive Transports** building block (`SimulationBuilder.cs:100-102`, `:268`), never to the transports nested in a molecule.

So under "Extend" a redefinition of an existing active transport process applies its parameters but silently keeps the earlier module's kinetic equation, source/target criteria and process rate parameter properties. Those are exactly the properties that determine the transport in the model — `TransportBuilderToTransportMapper.MapFrom` reads the formula and `CreateProcessRateParameter`, and `TransportCreator.getNeighborhoodsForActiveTransport` selects the neighborhoods from the criteria.

This PR documents the actual behavior in [Molecules](https://github.com/Open-Systems-Pharmacology/docs/blob/v13/part-4/modularization-concept.md#molecules) and in the corresponding bullet and migration-impact paragraph of the v12→v13 page, each marked with a TODO linking to Open-Systems-Pharmacology/MoBi#2493, which tracks the implementation side. The same root cause is already tracked for the transports inside events in Open-Systems-Pharmacology/OSPSuite.Core#2943, and the new Events section added by Open-Systems-Pharmacology/MoBi#359 documents it correctly there — this brings the Molecules section in line, so the manual no longer describes the same code path in two contradicting ways.

Note on Open-Systems-Pharmacology/MoBi#359: it edits the two `**Parameters**` bullets immediately above and below the line changed here, so one of the two branches will need a trivial conflict resolution depending on merge order. The changed lines themselves do not overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
