### PR TITLE
Fix the order in which parameter values are applied

### DIFF
--- a/part-4/converting-v12-projects-to-v13.md
+++ b/part-4/converting-v12-projects-to-v13.md
@@ -164,7 +164,7 @@ This first-module precedence is considered a bug — the administered molecule s
 
 ### Unchanged
 
-- **Parameter Values** — resolution order (Building Block → Individual → Expression Profile → PV BB, latest module wins) is unchanged.
+- **Parameter Values** — resolution order (Building Block → Expression Profile → Individual → PV BB, latest module wins) is unchanged.
 - **Initial Conditions** — resolution order (Molecules BB → Expression Profiles → IC BBs, latest module wins) is unchanged.
 
 ## Migration steps

--- a/part-4/modularization-concept.md
+++ b/part-4/modularization-concept.md
@@ -252,15 +252,17 @@ For each event:
 
 ### Parameter values
 
-The final values or formulas of the parameters in a simulation are determined in the following order:
+The final values or formulas of the parameters in a simulation are determined in the following order. The values are applied in this sequence, so a value applied later overwrites a value applied before it:
 
 1. **Values defined in the building block:** first, the value defined in the BB where the parameter is defined. For example, the value of `CYP3A4|Reference concentration` is set to 1 µmol/l in the Molecules BB. If a simulation is created using only this Molecules BB and no Expression Profile or PV BB is selected, the value will be 1 µmol/l.
 
-2. **Values defined in the individual.** If an individual is selected, the values from the individual are applied. When applying an individual to a PK-Sim module only, the parameters defined in the individual are not present in the spatial structure of the PK-Sim module. **These parameters are added to the model when the simulation is created.**
+2. **Values defined in an Expression Profile.** If an expression profile is selected, the values from the expression profile are applied. For example, `CYP3A4|Reference concentration` is set to 1 µmol/l in the Molecules BB, and 4.32 µmol/l in the Expression Profile. If a simulation is created with the module with the Molecules BB and the Expression Profile, the value will be 4.32 µmol/l (overriding the value from the Molecules BB).
+
+3. **Values defined in the individual.** If an individual is selected, the values from the individual are applied. When applying an individual to a PK-Sim module only, the parameters defined in the individual are not present in the spatial structure of the PK-Sim module. **These parameters are added to the model when the simulation is created.**
+
+    The individual is applied *after* the expression profiles. If a parameter is defined in both, the value from the individual is used. This is required for aging simulations, where the individual defines a parameter such as the ontogeny factor of a protein as a time-dependent table formula, while the expression profile defines it as a constant value.
 
     One special case occurs when an extension module explicitly defines a parameter in the spatial structure that is also present in the individual. In this case, the value from the individual will overwrite the value (or formula) defined in the extension module. To overwrite parameters defined in an individual (e.g. defining the volume of an organ as an age-dependent table rather than a constant value), define this parameter in the 'Parameter Values' section of an extension module.
-
-3. **Values defined in an Expression Profile.** If an expression profile is selected, the values from the expression profile are applied. For example, `CYP3A4|Reference concentration` is set to 1 µmol/l in the Molecules BB, and 4.32 µmol/l in the Expression Profile. If a simulation is created with the module with the Molecules BB and the Expression Profile, the value will be 4.32 µmol/l (overriding the value from the Molecules BB).
 
 4. **Values defined in PV BBs.** If a module containing a PV BB is selected, the values from the PV BB are applied. If multiple modules contain PV BBs with entries for the same parameters, the value from the latest module is selected. For example, if the Extension module contains an entry for `CYP3A4 Reference concentration`with a value of 2 µmol/l and a simulation is created using the Molecules BB module with a value of 1 µmol/l, the Expression Profile module with a value of 4.32 µmol/l and the PV BB module with a value of 2 µmol/l, the value in the simulation will be 2 µmol/l.
 


### PR DESCRIPTION
Item 5 of the re-review in #335.

The **Parameter values** section lists the individual as step 2 and the expression profile as step 3. Since the list is introduced as "determined in the following order" — and steps 3 and 4 are worded as later-wins ("overriding the value from the Molecules BB", "the value from the latest module is selected") — it reads as *expression profile beats individual*. The implementation is the other way round (`OSPSuite.Core/Domain/Services/QuantityValuesUpdater.cs:57-72`):

```csharp
updateMoleculeAmountFromInitialConditions(modelConfiguration);

//Add expressions profile before individual as some settings might be overwritten in the individual for aging
updateParameterFromExpressionProfiles(valueUpdater);

updateParameterFromIndividualValues(valueUpdater);

//PV are applied last
updateParameterValueFromParameterValues(valueUpdater);
```

So for a parameter defined in both, **the value from the individual wins**, deliberately.

This is not a theoretical difference. PK-Sim normally keeps expression and ontogeny parameters out of the individual building block (`IndividualToIndividualBuildingBlockMapper.shouldExportParameter` filters them), but the aging conversion writes them back in: `DistributedParameterToTableParameterConverter.createParameterValueVersionOntogenyTableParameter` puts `<Protein>|Ontogeny factor` / `Ontogeny factor GI` into the individual as a `TableFormula` with `Value = null`, while the expression profile carries the same paths as constants. If the documented order were the implemented one, every aging simulation would lose the ontogeny time-dependence.

This PR:

- swaps steps 2 and 3 so the sequence matches the implementation (Building Block → Expression Profile → Individual → PV BB), keeping the text of each step;
- makes the semantics of the list explicit — "a value applied later overwrites a value applied before it" — which is what made the inversion easy to miss;
- adds one paragraph explaining why the individual has to win, so the ordering does not look like an error to the next reader;
- corrects the same sequence in the "Unchanged" summary of the v12→v13 page.

The order itself has been in place since the modularization work in 2023 (`3c18ced2`), so the migration page's statement that the resolution order is *unchanged* between v12 and v13 remains correct — only the sequence it quotes was wrong.

No overlap with #359 or #370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
