### PR TITLE
Fix the merge description of the molecule Include/Exclude lists

### DIFF
--- a/part-4/converting-v12-projects-to-v13.md
+++ b/part-4/converting-v12-projects-to-v13.md
@@ -91,7 +91,7 @@ The same trap applies to **modifiers**: if one definition carries a modifier the
   - Kinetic **equation** is overwritten.
   - **Parameters** list is **extended**.
   - **Source** and **target** lists are **extended**; their operators are overwritten.
-  - **Include/Exclude** molecule lists are extended; the **"All" checkbox** behavior is overwritten (an exclusion in the later module takes precedence).
+  - **Include/Exclude** molecule lists are extended; the **"All" checkbox** state is overwritten. Since the checkbox decides which of the two lists is evaluated, a later module that checks "All" widens the transport to every molecule except the excluded ones — see [Passive transports](modularization-concept.md#passive-transports).
 - **Merge behavior "Overwrite"**
   - The passive transport is **completely overwritten by name**.
 
@@ -126,7 +126,7 @@ In a controlled test with two large-molecule PK-Sim modules, the **v13 "Extend" 
   - Monitoring **equation** is overwritten.
   - The **operator** of the "In container with" list is overwritten.
   - The **conditions** list of "In container with" is **extended**.
-  - **Include/Exclude** molecule lists are extended; the **"All" checkbox** behavior is overwritten.
+  - **Include/Exclude** molecule lists are extended; the **"All" checkbox** state is overwritten. As for passive transports, a later module that checks "All" widens the observer to every molecule except the excluded ones — see [Observers](modularization-concept.md#observers).
 - **Merge behavior "Overwrite"**
   - The observer is **completely overwritten by name**.
 

--- a/part-4/modularization-concept.md
+++ b/part-4/modularization-concept.md
@@ -169,8 +169,9 @@ Reactions are completely overwritten by name.
 
 - **Source** and **Target** lists are extended.
 
-- **Include/Exclude** molecule lists for molecules are always extended. However, the behavior of the **All checkbox** is overwritten.
-  - Example: `Module A` includes `MolA` and `MolB`, `Module B` has "Calculate for All" checked and `MolB` excluded. The final model will include only `MolA`, even if `MolB` is specified in the include list of `Module A`. The exclusion list of `Module B` takes precedence.
+- **Include/Exclude** molecule lists are extended: the molecules listed in module `B` are added to the respective list and removed from the other one. The state of the **All checkbox** is overwritten by module `B`.
+  - Only one of the two lists is evaluated when the simulation is created (see [Passive Transports](passive-transports-bb.md)): if the **All** checkbox is checked, the transport is created for all molecules *except* those in the Exclude List, and the Include List is ignored; if it is not checked, the transport is created only for the molecules in the Include List, and the Exclude List is ignored.
+  - Example: `Module A` has the **All** checkbox unchecked and `MolA` and `MolB` in its Include List. `Module B` has **All** checked and `MolB` in its Exclude List. In the final model, the checkbox is checked and the Exclude List contains `MolB`, so the transport is created for **all molecules except `MolB`** - not only for `MolA`, and also for molecules that neither of the two modules mentions.
 
 #### Merge behavior "Overwrite"
 
@@ -186,8 +187,9 @@ Passive transports are completely overwritten by name.
 
 - The **Conditions** list of the "In container with" list is extended.
 
-- **Include/Exclude** molecule lists for molecules are always extended. However, the behavior of the **All checkbox** is overwritten.
-  - Example: `Module A` includes `MolA` and `MolB`, `Module B` has "Calculate for All" checked and `MolB` excluded. The final model will include only `MolA`, even if `MolB` is specified in the include list of `Module A`. The exclusion list of `Module B` takes precedence.
+- **Include/Exclude** molecule lists are extended: the molecules listed in module `B` are added to the respective list and removed from the other one. The state of the **All checkbox** is overwritten by module `B`.
+  - Only one of the two lists is evaluated when the simulation is created (see [Observers](observers-bb.md)): if the **All** checkbox is checked, the observer is created for all molecules *except* those in the Exclude List, and the Include List is ignored; if it is not checked, the observer is created only for the molecules in the Include List, and the Exclude List is ignored.
+  - Example: `Module A` has the **All** checkbox unchecked and `MolA` and `MolB` in its Include List. `Module B` has **All** checked and `MolB` in its Exclude List. In the final model, the checkbox is checked and the Exclude List contains `MolB`, so the observer is created for **all molecules except `MolB`** - not only for `MolA`, and also for molecules that neither of the two modules mentions.
 
 #### Merge behavior "Overwrite"
 


### PR DESCRIPTION
Item 6 of the re-review in #335.

The example under *Include/Exclude molecule lists* concluded: "The final model will include only `MolA`, even if `MolB` is specified in the include list of `Module A`. The exclusion list of `Module B` takes precedence." The conclusion is wrong, and it is wrong in the direction that hides a real risk — the merged process is created for **more** molecules than either module listed, not fewer.

`SimulationBuilder.mergeMoleculeLists` produces `ForAll = true`, Include `{MolA}`, Exclude `{MolB}` for the documented case. Resolution then ignores the include list entirely, because `ForAll` decides which list is read:

```csharp
// MoleculeList.cs (used for passive transports via TransportCreator)
if (ForAll && !MoleculeNamesToExclude.Contains(moleculeName)) return true;
if (!ForAll && MoleculeNames.Contains(moleculeName)) return true;
return false;

// ObserverBuilderTask.moleculeBuildersValidFor does the same for observers
if (moleculeList.ForAll)
   return allMolecules.Where(molecule => !moleculeList.MoleculeNamesToExclude.Contains(molecule.Name));
return allMolecules.Where(molecule => moleculeList.MoleculeNames.Contains(molecule.Name));
```

So the result is every molecule **except** `MolB` — including molecules that neither module mentioned. `MolB` is dropped because "All" is checked and it is excluded, not because an exclusion beats an inclusion. The documented conclusion happens to be right only when the simulation contains exactly `MolA` and `MolB`.

This PR, for passive transports and observers alike:

- says what the merge does to the two lists (molecules of module `B` added to the respective list and removed from the other one, "All" checkbox state taken from module `B`);
- adds the missing piece — only one of the two lists is evaluated, depending on the checkbox — with a link to the building-block page that already documents that rule ([Passive Transports](https://github.com/Open-Systems-Pharmacology/docs/blob/v13/part-4/passive-transports-bb.md), [Observers](https://github.com/Open-Systems-Pharmacology/docs/blob/v13/part-4/observers-bb.md));
- rewrites the example with the correct outcome, naming explicitly that the process is created for molecules neither module mentions;
- replaces the misleading "an exclusion in the later module takes precedence" parenthesis on the v12→v13 page with the actual consequence (a later module that checks "All" widens the process).

Note that this is also the mechanism behind the existing warning on the migration page about combining two large-molecule PK-Sim modules under "Overwrite" — that hint stays valid; this PR only corrects the "Extend" description.

No overlap with #359, #370 or #371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
