### PR TITLE
Clarify that parameter tags are not extended when merging modules

### DIFF
--- a/part-4/modularization-concept.md
+++ b/part-4/modularization-concept.md
@@ -90,14 +90,16 @@ When combining modules `A` and `B` (with the hierarchy `A <- B`), all containers
 - **MoleculeProperties** are always extended. That means that new molecule properties from module `B` will be added to the existing ones in module `A`. If module `B` has a molecule property that is also present in module `A`, the property (its constant value or formula) from module `B` will be used.
 - **Parameters** are always overwritten. If both modules have a parameter `Organism|Container 1|Param`, the parameter from module `B` will be used. This applies to all properties of the parameter (value, formula, unit, tags etc).
 - **Container types** (physical or logical) will be overwritten. If "Organism|Container 1" is "physical" in module "A" and "logical" in module "B", the container will be "logical" in the final model.
-- **Tags** will be extended. If "Organism|Container 1" has a tag "Tag A" in module "A" and a tag "Tag B" in module "B", in the final model, "Organism|Container 1" will have tags "Tag A" and "Tag B".
+- **Tags** of containers and neighborhoods will be extended. If "Organism|Container 1" has a tag "Tag A" in module "A" and a tag "Tag B" in module "B", in the final model, "Organism|Container 1" will have tags "Tag A" and "Tag B". A tag defined in module `A` can never be removed by module `B`. The tags of a **parameter** are *not* extended: as stated above, a parameter is replaced as a whole, so it only has the tags defined in module `B`.
 - **Neighborhoods** are extended (e.g., addition of new parameters, tags). Neighbors are replaced. If module `A` defines a neighborhood `N1` between `Organism|Container 1` and `Organism|Container 2`, and module `B` defines a neighborhood `N1` between `Organism|Container 2` and `Organism|Container 3`, the final model will contain a neighborhood `N1` between `Organism|Container 2` and `Organism|Container 3`.
 
 {% hint style="warning" %}
 If module `B` defines the neighborhood `N1` with invalid neighbors (so it cannot be created), the neighborhood from module `A` will be used as is! It is not possible to remove neighborhoods from the model.
 {% endhint %}
 
-
+{% hint style="warning" %}
+Redefining a parameter in module `B` removes the tags that this parameter has in module `A`, even if the only intention was to change its value. Parameter tags are used to select parameters in [sum formulas](parameters-formulas-tags.md#sum-formulas), so a sum formula defined in module `A` will silently stop taking such a parameter into account. To avoid this, repeat all tags of the parameter in module `B`. Conditions that use the name of the parameter or the tags of its container are not affected, as the name of an entity also acts as a tag.
+{% endhint %}
 
 #### Merge behavior "Overwrite"
 When combining modules `A` and `B` (with the hierarchy `A <- B`), all containers from module `B` will overwrite the containers with the same path in module `A`. When overwriting, all descendants of a container are removed if not present in the module that overwrites (i.e., replacement of the whole tree structure). I.e., if module `A` has a container `Organism|Container 1` with two sub-containers `Container 2` and `Container 3` (absolute paths: `Organism|Container 1|Container 2` and `Organism|Container 1|Container 2`), and module `B` has a container `Organism|Container 1` without any sub-containers, the final model will contain `Organism|Container 1` without the sub-containers `Container 2` and `Container 3`. `Organism|Container 1` will only have parameters that are defined in module `B`, but not in module `A`.


### PR DESCRIPTION
Item 7 of the re-review in #335.

Under Spatial structure → "Extend", the bullet "**Tags** will be extended" is unqualified, so it reads as a rule for tags in general. It holds for containers and neighborhoods only. Parameter tags are *not* extended: a parameter is not merged but replaced as a whole object, so it ends up with the tags of module `B` alone.

`ContainerMergeTask.MergeContainers` unions tags in `updateContainerProperties`, but only for the containers it recurses into. Everything that is not a container — parameters, and distributed parameters, which are explicitly filtered out of the container list — goes through `AddOrReplaceInContainer`, which removes the existing child and adds the new one:

```csharp
targetContainer.Mode = containerToMerge.Mode;
containerToMerge.Tags.Each(targetContainer.AddTag);        // containers only
…
var allChildrenContainerToMerge = containerToMerge.GetChildren<IContainer>(x => !x.IsAnImplementationOf<IDistributedParameter>()).ToList();
var allChildrenEntitiesToMerge = containerToMerge.GetChildren<IEntity>().Except(allChildrenContainerToMerge).ToList();
…
allChildrenEntitiesToMerge.Each(x => AddOrReplaceInContainer(targetContainer, x));
```

The distinction is asserted by three integration tests on the same merged model (`ModuleIntegrationTests.cs`): `should_have_merged_the_tag_at_the_container_level`, `should_have_merged_the_tag_at_the_neighborhood_level`, and `should_have_not_merged_the_tag_at_the_parameter_level`, the last of which checks that the tag defined on the parameter in the earlier module is **absent** from the merged parameter.

The list already says one line above that a parameter is overwritten including its tags, so as it stands the section states both rules and leaves the reader to decide which one applies. This PR:

- qualifies the bullet to containers and neighborhoods, states that a tag from module `A` can never be removed at that level, and names the parameter exception explicitly, pointing back to the "Parameters" bullet rather than repeating it;
- adds a warning for the consequence, which is the part that is easy to be caught by: parameter tags select parameters in [sum formulas](https://github.com/Open-Systems-Pharmacology/docs/blob/v13/part-4/parameters-formulas-tags.md#sum-formulas), so redefining a parameter in an extending module just to change its value drops it out of a sum defined in the module above, with no error and no visible change at the parameter itself. The remedy — repeat the tags in module `B` — is stated, as is the fact that conditions matching the parameter *name* or the *container* tags keep working, since a name also acts as a tag.

This is not a v13 change: the wording is identical in the v12 manual (`master`), and `ContainerMergeTask` has not changed since it was introduced. The v12→v13 page therefore needs no edit — its Spatial structure section defers with "the container/parameter/tag/neighborhood rules are essentially as in v12" and lists only the two rules that did change.

No overlap with #359, #370, #371 or #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
