### PR TITLE
Document "Track observed data used by a simulation, as in PK-Sim"

### DIFF
--- a/part-4/setting-up-simulation.md
+++ b/part-4/setting-up-simulation.md
@@ -269,7 +269,7 @@ Parameters associated with Event and Application Properties can be accessed at t
 
 ## Update and Commit Changes Between Simulations and Modules.
 
-Within the **Simulation Explorer**, each building block item of the **Configuration** tree is displayed with a green or red traffic light. The traffic lights indicate if the building block item of the simulation is consistent with the corresponding general **Building Block**. If a **Building Block** or parameter settings within a **Simulation** are changed, the red traffic lights in the **Simulation** window indicate that the local settings in the simulation are different from the settings in the general **Building Block**.
+Within the **Simulation Explorer**, each building block item listed below a simulation is displayed with a green or red traffic light. The traffic lights indicate if the building block item of the simulation is consistent with the corresponding general **Building Block**. If a **Building Block** or parameter settings within a **Simulation** are changed, the red traffic lights in the **Simulation** window indicate that the local settings in the simulation are different from the settings in the general **Building Block**.
 
 A right click on the red traffic lights in the **Simulation** window allows for two actions:
 
@@ -294,6 +294,8 @@ If no Parameter Values or Initial Conditions building block is selected for the 
 ## Further Options for Simulations
 
 Once a simulation is created, a number of options besides simply running the simulation are available.
+
+Clicking on the + sign of the simulation will expand the entry and show the **modules and building blocks** used in the corresponding simulation. A module entry is again expandable by a click on the + sign in front of it and yields the building blocks of that module. The expanded simulation entry also lists the observed data used by the simulation (see [Observed Data used by a Simulation](simulation-results.md#observed-data-used-by-a-simulation)).
 
 ### Calculate Scale Divisors
 

--- a/part-4/setting-up-simulation.md
+++ b/part-4/setting-up-simulation.md
@@ -295,7 +295,7 @@ If no Parameter Values or Initial Conditions building block is selected for the 
 
 Once a simulation is created, a number of options besides simply running the simulation are available.
 
-Clicking on the + sign of the simulation will expand the entry and show the **modules and building blocks** used in the corresponding simulation. A module entry is again expandable by a click on the + sign in front of it and yields the building blocks of that module. The expanded simulation entry also lists the observed data used by the simulation (see [Observed Data used by a Simulation](simulation-results.md#observed-data-used-by-a-simulation)).
+Clicking on the expand icon in front of the simulation will expand the entry and show the **modules and building blocks** used in the corresponding simulation. A module entry is again expandable by a click on the expand icon in front of it and yields the building blocks of that module. The expanded simulation entry also lists the observed data used by the simulation (see [Observed Data used by a Simulation](simulation-results.md#observed-data-used-by-a-simulation)).
 
 ### Calculate Scale Divisors
 

--- a/part-4/simulation-results.md
+++ b/part-4/simulation-results.md
@@ -26,6 +26,21 @@ To display the data in a new chart right-click on the data and select <img src="
 
 To display the dataset in an existing chart window, simply drag\&drop the dataset into the chart. The observed dataset is then also listed in the data browser of the chart editor.
 
+### Observed Data used by a Simulation
+
+As in PK-Sim®, each simulation keeps track of the observed data it uses. An observed dataset is added to a simulation
+
+* when it is dragged\&dropped into a chart of the simulation, or
+* via the context menu: while the simulation is open for editing, right-click on the dataset in the Building Block Explorer and select **Add to Simulation '\<simulation name>'**. The entry is only offered if the active simulation does not already use the dataset.
+
+The observed data used by a simulation are listed in the Simulation Explorer below the corresponding simulation and are saved with the project. Because this association is independent of the charts, the datasets remain available in the data browser of the chart editor even if they are currently not plotted, e.g., after re-running the simulation or after applying a chart template.
+
+To remove an observed dataset from a simulation, right-click on the dataset below the simulation in the Simulation Explorer and select <img src="../assets/icons/Cancel.svg" alt="" data-size="line"> **Remove** in the context menu. The dataset is then removed from the simulation and its charts but remains in the project. An observed dataset that is used together with the simulation in a parameter identification cannot be removed from the simulation.
+
+{% hint style="info" %}
+When a project created with an earlier version of MoBi® is opened, the list of observed data used by each simulation is automatically initialized from the curves of the simulation charts and from the output mappings of the simulation.
+{% endhint %}
+
 ### Deleting imported Observed Data
 
 To delete imported observed data from the project right-click on the data and select <img src="../assets/icons/Cancel.svg" alt="Image" data-size="line"> **Remove** in the context menu (or simply press the **Delete** key on your keyboard to delete the selected data). This also removes the data from the chart and the data browser of the chart editor.


### PR DESCRIPTION
Fixes #362

Documents the MoBi v13 feature from Open-Systems-Pharmacology/MoBi#2474 (implemented in Open-Systems-Pharmacology/MoBi#2477): simulations now explicitly track the observed data they use, as in PK-Sim.

- **part-4/simulation-results.md**: new section "Observed Data used by a Simulation" describing how observed data becomes associated with a simulation (chart drag & drop, or the "Add to Simulation '<simulation name>'" context menu entry), that the used data is listed below the simulation in the Simulation Explorer and saved with the project, that it stays available in the chart editor across re-runs and chart template loads, the Remove action and its caveats, and the automatic initialization from chart curves and output mappings when converting projects from earlier versions.
- **part-4/setting-up-simulation.md**: describes what expanding a simulation node shows (modules and their building blocks, plus the used observed data) and fixes a leftover reference to the former "Configuration" tree in the Update/Commit section.

PK-Sim already documents this behavior briefly (part-3/pk-sim-simulations.md, "associated to that simulation ... removed by removing the observed data from the simulation tree"), so both applications now cover it.

The multi-select "Add to Simulation" entry is intentionally not documented — that is Open-Systems-Pharmacology/OSPSuite.Core#2932, still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)