### PR TITLE
Document the "Warn for non-finite quantities" option

### DIFF
--- a/part-4/mobi-options.md
+++ b/part-4/mobi-options.md
@@ -12,6 +12,8 @@ MoBi can be customized using several options. To do this, click on the **Options
 Always check which elements are renamed when this option is enabled. Sometimes, not all suggested renamings are desired
 {% endhint %}
 
+- **Warn for non-finite quantities**: If enabled, a warning will be shown in the **Notifications** view for each quantity whose value is `NaN` or infinite at time `t=0`. The check is performed when a simulation is created and each time it is run.
+
 -   **Number of recent file items shown**: Changes the number of recent documents displayed within the File Tab. The program needs to be restarted for the changes to take effect.
 - **Decimal places**: Changes the number of decimal places shown in numerical fields throughout the application.
 


### PR DESCRIPTION
Adds the missing **Warn for non-finite quantities** entry to the MoBi Options page (General tab).

The wording follows the tooltip added in [MoBi#2515](https://github.com/Open-Systems-Pharmacology/MoBi/pull/2515) for [MoBi#2511](https://github.com/Open-Systems-Pharmacology/MoBi/issues/2511):

> Show a warning for each quantity whose value is NaN or infinite at time t=0.
> The check is performed when a simulation is created and each time it is run.

Notes:
- Placed in dialog order — directly after *Rename Dependent Elements*, before *Number of recent file items shown*.
- Phrased to match the surrounding validation entries, which say warnings appear in the **Notifications** view. The tooltip itself does not name the destination, so please confirm that is where these warnings surface.
- MoBi-only setting, so `part-3/pk-sim-options.md` is untouched.

Fixes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)